### PR TITLE
Remove jitpack 	maven artifact repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,8 +48,7 @@ allprojects {
             }
         }
         google()
-        maven { url 'https://www.jitpack.io' }
-                if (project.hasProperty('onegini_artifactory_user') && project.hasProperty('onegini_artifactory_password')) {
+        if (project.hasProperty('onegini_artifactory_user') && project.hasProperty('onegini_artifactory_password')) {
             maven {
                 url "https://repo.onegini.com/artifactory/onegini-sdk"
                 credentials {


### PR DESCRIPTION
This repository was not being used and was causing some issues on bitrise, so let's remove it here aswel.