### PR TITLE
RNP-157: Show dialog when starting sdk without internet connection

### DIFF
--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -32,7 +32,7 @@ declare global {
 }
 
 const App: React.FC<{}> = () => {
-  const {isBuilt, isSdkError, startSDK} = useSDK();
+  const {isBuilt, sdkError, startSDK} = useSDK();
   const {
     state: {authorized: isAuthorized},
   } = useContext(AuthContext);
@@ -43,8 +43,7 @@ const App: React.FC<{}> = () => {
   }, []);
 
   const Stack = createNativeStackNavigator<RootStackParamList>();
-
-  if (!isBuilt || isSdkError) {
+  if (!isBuilt || sdkError != null) {
     return <SplashScreen />;
   }
 

--- a/src/components/app/AppBootstrap.tsx
+++ b/src/components/app/AppBootstrap.tsx
@@ -5,17 +5,20 @@ import App from './App';
 import {ActionSheetProvider} from '@expo/react-native-action-sheet';
 import {Provider as PaperProvider} from 'react-native-paper';
 import OneWelcomeTheme from '../constants/Theme';
+import DialogProvider from '../../providers/dialogProvider';
 
 const AppBootstrap: React.FC<{}> = () => {
   return (
     <PaperProvider theme={OneWelcomeTheme}>
-      <ActionSheetProvider>
-        <NavigationContainer>
-          <AuthProvider>
-            <App />
-          </AuthProvider>
-        </NavigationContainer>
-      </ActionSheetProvider>
+      <DialogProvider>
+        <ActionSheetProvider>
+          <NavigationContainer>
+            <AuthProvider>
+              <App />
+            </AuthProvider>
+          </NavigationContainer>
+        </ActionSheetProvider>
+      </DialogProvider>
     </PaperProvider>
   );
 };

--- a/src/helpers/useSDK.ts
+++ b/src/helpers/useSDK.ts
@@ -1,21 +1,30 @@
 import OneWelcomeSdk from 'onewelcome-react-native-sdk';
-import {Alert, Linking} from 'react-native';
-import {useEffect, useState} from 'react';
+import {Linking} from 'react-native';
+import {useContext, useEffect, useState} from 'react';
+import DialogContext from '../providers/dialogContext';
 
 export const useSDK = () => {
   const [isBuilt, setBuilt] = useState(false);
-  const [isSdkError, setSdkError] = useState(false);
+  const [sdkError, setSdkError] = useState(null);
   const [redirectUri, setRedirectUri] = useState('');
+  const {showDialog, closeDialog} = useContext(DialogContext);
   const startSDK = async () => {
     console.log('startsdk');
+
     try {
+      closeDialog();
       await OneWelcomeSdk.startClient();
       const uri = await OneWelcomeSdk.getRedirectUri();
+      setSdkError(null);
       setBuilt(true);
       setRedirectUri(uri);
     } catch (e: any) {
-      Alert.alert(`Error when starting SDK. Code:${e.code}`, e.message);
-      setSdkError(true);
+      showDialog({
+        title: 'Could not start the SDK',
+        message: e?.message,
+        onCloseDialog: startSDK,
+      });
+      setSdkError(e?.message);
     }
   };
 
@@ -36,7 +45,7 @@ export const useSDK = () => {
 
   return {
     isBuilt,
-    isSdkError,
+    sdkError,
     redirectUri,
     startSDK,
   };

--- a/src/providers/dialogContext.tsx
+++ b/src/providers/dialogContext.tsx
@@ -1,0 +1,20 @@
+// dialogContext.tsx
+import {createContext} from 'react';
+
+export type DialogValueType = {
+  title: String;
+  message: String;
+  onCloseDialog: () => void;
+};
+
+export type DialogContextType = {
+  showDialog: (content: DialogValueType) => void;
+  closeDialog: () => void;
+};
+
+const DialogContext = createContext<DialogContextType>({
+  showDialog: () => {},
+  closeDialog: () => {},
+});
+
+export default DialogContext;

--- a/src/providers/dialogProvider.tsx
+++ b/src/providers/dialogProvider.tsx
@@ -1,0 +1,52 @@
+// DialogProvider.tsx
+import React, {useState} from 'react';
+import DialogContext, {
+  DialogContextType,
+  DialogValueType,
+} from './dialogContext';
+import {Button, Dialog, Portal, Text} from 'react-native-paper';
+
+type DialogProviderProps = {
+  children: React.ReactNode;
+};
+
+const DialogProvider: React.FC<DialogProviderProps> = ({children}) => {
+  const [dialogContent, setDialogContent] = useState<DialogValueType | null>(
+    null,
+  );
+
+  const showDialog: DialogContextType['showDialog'] = content => {
+    setDialogContent(content);
+  };
+
+  const closeDialog: DialogContextType['closeDialog'] = () => {
+    setDialogContent(null);
+  };
+
+  const dialog = dialogContent && (
+    <Dialog visible={!!dialogContent}>
+      <Dialog.Title>Could not start the SDK</Dialog.Title>
+      <Dialog.Content>
+        <Text variant="bodyMedium">{dialogContent.message}</Text>
+      </Dialog.Content>
+      <Dialog.Actions>
+        <Button
+          onPress={() => {
+            dialogContent.onCloseDialog();
+            closeDialog();
+          }}>
+          Try again
+        </Button>
+      </Dialog.Actions>
+    </Dialog>
+  );
+
+  return (
+    <DialogContext.Provider value={{showDialog, closeDialog}}>
+      {dialog && <Portal>{dialog}</Portal>}
+      {children}
+    </DialogContext.Provider>
+  );
+};
+
+export default DialogProvider;


### PR DESCRIPTION
This commit adds a dialog which allows the user to try again to start the SDK when it fails for any reason, likely no internet. The message is taken from the error from startClient().